### PR TITLE
Create basic property detail card

### DIFF
--- a/frontend/src/components/PropertyDetailCard.js
+++ b/frontend/src/components/PropertyDetailCard.js
@@ -1,0 +1,14 @@
+function PropertyDetailCard(props) {
+    const property = props.property;
+    return (
+      <div>
+          <header>{ property.name ? property.name : property.id }</header>
+          <div>
+              <span>{ property.bed } bath</span>
+              <span> { property.bath } bed</span>
+          </div>
+          <p>{property.address}</p>
+      </div>
+    );
+}
+export default PropertyDetailCard;

--- a/frontend/src/components/PropertyDetailCard.js
+++ b/frontend/src/components/PropertyDetailCard.js
@@ -1,13 +1,16 @@
+import "./PropertyDetailCardHome.css";
+
 function PropertyDetailCard(props) {
     const property = props.property;
     return (
-      <div>
+        <div className={`property-card-${props["parent-style"]}`}>
           <header>{ property.name ? property.name : property.id }</header>
-          <div>
+          <div className="bed-and-bath property-detail">
               <span>{ property.bed } bath</span>
-              <span> { property.bath } bed</span>
+              <span className="separator">|</span>
+              <span>{ property.bath } bed</span>
           </div>
-          <p>{property.address}</p>
+          <p className="property-detail" >{property.address}</p>
       </div>
     );
 }

--- a/frontend/src/components/PropertyDetailCardHome.css
+++ b/frontend/src/components/PropertyDetailCardHome.css
@@ -1,0 +1,31 @@
+.property-card-parent-style-home {
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.property-card-parent-style-home header  {
+    font-size: 40px;
+    font-weight: bold;
+    color: #1F355E;
+    margin-bottom: 10px;
+}
+
+.property-card-parent-style-home .property-detail {
+    color: #58575C;
+    font-size: 18px;
+    margin-bottom: 5px;
+}
+
+.property-card-parent-style-home .bed-and-bath {
+    display: flex;
+    align-items: center;
+}
+
+.property-card-parent-style-home .bed-and-bath span {
+    margin-right: 5px;
+}
+
+.property-card-parent-style-home p {
+    margin: 0;
+}


### PR DESCRIPTION
Card containing the basic property details. 

It is based on the below reference. However, instead of the price, the property `name` or `id` would be the header instead.
![image](https://github.com/ryanzhxu/estate-flow/assets/100311477/69a4dadb-17b9-4546-b307-e5c05e81b2dc)

Also added some CSS styling and included a property called `parent-style` to conditionally apply CSS based on the parent component, since the idea is that this component will be reused for the property home page and the navigation bar.

