### PR TITLE
Set initial `tenantSelected` value back to null

### DIFF
--- a/client/src/redux/tenants/tenantsReducer.js
+++ b/client/src/redux/tenants/tenantsReducer.js
@@ -5,7 +5,7 @@ const INITIAL_STATE = {
     tenants: [],
     isTenantDetailOpen: false,
     isTenantAddOpen: false,
-    tenantSelected: {}
+    tenantSelected: null
 };
 
 const tenantsSlice = createSlice({


### PR DESCRIPTION
Was testing latest changes and found that the tenant home page was no longer working. Realized that this was because the initial `tenantSelected` value had been set to `{}` instead of `null`. 

Whether the `tenant` data has been retrieved or not checked by looking at whether `tenantSelected` is null or not.