### PR TITLE
fixes to tenant overview card and repopulation

### DIFF
--- a/client/src/components/tenant/TenantOverviewCard.js
+++ b/client/src/components/tenant/TenantOverviewCard.js
@@ -38,7 +38,7 @@ function TenantOverviewCard({ tenant }) {
           <p className='mb-0'>Date of Birth</p>
         </div>
         <div className='col-sm-7'>
-          <p className='text-muted mb-0'>{new Date(tenant.birthDate).toLocaleDateString()}</p>
+          <p className='text-muted mb-0'>{tenant.birthDate? new Date(tenant.birthDate).toLocaleDateString() : 'Not Provided'}</p>
         </div>
       </div>
       <hr />
@@ -47,7 +47,7 @@ function TenantOverviewCard({ tenant }) {
           <p className='mb-0'>Employment</p>
         </div>
         <div className='col-sm-7'>
-          <p className='text-muted mb-0'>{tenant.occupation}</p>
+          <p className='text-muted mb-0'>{tenant.occupation? tenant.occupation : 'Not Provided'}</p>
         </div>
       </div>
     </div>

--- a/client/src/shared/components/InputField.js
+++ b/client/src/shared/components/InputField.js
@@ -37,7 +37,7 @@ const InputField = ({
           id={field}
           key={field}
           name={field}
-          defaultValue={defaultValue}
+          defaultValue={type === 'date'? defaultValue.slice(0,10) : defaultValue}
           onChange={onChangeHandler}
         />
       )}

--- a/client/src/shared/constants/tenant/RequiredFields.js
+++ b/client/src/shared/constants/tenant/RequiredFields.js
@@ -1,1 +1,1 @@
-export const RequiredFields = ['firstName', 'lastName', 'email', 'phoneNumber', 'propertyId'];
+export const RequiredFields = ['firstName', 'lastName', 'email', 'phoneNumber', 'propertyId', 'startDate', 'endDate', 'leaseType'];


### PR DESCRIPTION
Fixed overview card to display "Not Provided" when date and occupation are not filled. Also saw bug where birthdate was not repopulated when editing, fixed that bug.