### PR TITLE
Remove worker image field and added file filtering and error handling for image upload

### DIFF
--- a/server/aws/multer.js
+++ b/server/aws/multer.js
@@ -1,4 +1,5 @@
 const multer = require("multer");
+const {StatusCodes} = require("http-status-codes");
 const storage = multer.memoryStorage();
 
 const fileFilter = (req, file, cb) => {
@@ -9,6 +10,15 @@ const fileFilter = (req, file, cb) => {
     }
 };
 
+const handleMulterError = (err, req, res, next) => {
+    if (err instanceof multer.MulterError) {
+        return res.status(StatusCodes.BAD_REQUEST).json({ error: err.message });
+    } else if (err) {
+        return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: err.message });
+    }
+    next();
+};
+
 const upload = multer({
     storage: storage,
     fileFilter: fileFilter,
@@ -17,4 +27,4 @@ const upload = multer({
     }
 });
 
-module.exports = upload;
+module.exports = {upload, handleMulterError};

--- a/server/aws/multer.js
+++ b/server/aws/multer.js
@@ -1,5 +1,20 @@
 const multer = require("multer");
 const storage = multer.memoryStorage();
-const upload = multer({storage: storage});
+
+const fileFilter = (req, file, cb) => {
+    if (file.mimetype === "image/jpeg" || file.mimetype === "image/png") {
+        cb(null, true);
+    } else {
+        cb(new Error('Only image files of type jpg, png are allowed'), false);
+    }
+};
+
+const upload = multer({
+    storage: storage,
+    fileFilter: fileFilter,
+    limits: {
+        fileSize: 5 * 1024 * 1024 // 5MB
+    }
+});
 
 module.exports = upload;

--- a/server/models/worker.js
+++ b/server/models/worker.js
@@ -42,11 +42,7 @@ const workerSchema = new mongoose.Schema({
   trades: {
     type: String,
     required: true,
-  },
-  imageUrl: {
-    type: String,
-    required: false
-  },
+  }
 });
 
 const Worker = mongoose.model('Worker', workerSchema);

--- a/server/routes/properties.js
+++ b/server/routes/properties.js
@@ -44,7 +44,7 @@ router.get('/properties/:_id', async (req, res) => {
   }
 });
 
-router.post('/properties', upload.array("photos", 3), handleMulterError,  async (req, res) => {
+router.post('/properties', upload.array("photos", 5), handleMulterError,  async (req, res) => {
   if (req.files && req.files.length > 0) {
     const results = await uploadFile(req.files, "properties");
     req.body.photos = results.map((file) => file.Location);

--- a/server/routes/properties.js
+++ b/server/routes/properties.js
@@ -1,8 +1,8 @@
 const express = require('express');
 const Property = require('../models/property');
 const { StatusCodes } = require('http-status-codes');
-const upload = require("../aws/multer");
 const {uploadFile, deleteFiles, isStoredInCloud} = require("../aws/s3");
+const {handleMulterError, upload} = require("../aws/multer");
 
 const router = express.Router();
 
@@ -44,7 +44,7 @@ router.get('/properties/:_id', async (req, res) => {
   }
 });
 
-router.post('/properties', upload.array("photos"), async (req, res) => {
+router.post('/properties', upload.array("photos", 3), handleMulterError,  async (req, res) => {
   if (req.files && req.files.length > 0) {
     const results = await uploadFile(req.files, "properties");
     req.body.photos = results.map((file) => file.Location);

--- a/server/routes/tenants.js
+++ b/server/routes/tenants.js
@@ -3,9 +3,8 @@ const Tenant = require('../models/tenant');
 const Property = require('../models/property');
 const { StatusCodes } = require('http-status-codes');
 const mongoose = require('mongoose');
-const upload = require("../aws/multer");
 const {uploadFile, deleteFiles, isStoredInCloud} = require("../aws/s3");
-
+const {upload, handleMulterError} = require("../aws/multer");
 const router = express.Router();
 
 router.get('/tenants', async (req, res) => {
@@ -140,7 +139,7 @@ router.get('/tenants/dues/:date', async (req, res) => {
   }
 });
 
-router.post('/tenants', upload.single("profileImageUrl"), async (req, res) => {
+router.post('/tenants', upload.single("profileImageUrl"), handleMulterError, async (req, res) => {
   const propertyId = req.body.propertyId;
 
   if (!mongoose.isValidObjectId(propertyId)) {

--- a/server/routes/workers.js
+++ b/server/routes/workers.js
@@ -30,12 +30,7 @@ router.get('/workers/:_id', async (req, res) => {
   }
 });
 
-router.post('/workers', upload.single("imageUrl"), async (req, res) => {
-  if (req.file) {
-    const results = await uploadFile([req.file], "workers");
-    req.body.imageUrl = results[0].Location;
-  }
-
+router.post('/workers',async (req, res) => {
   const newWorker = new Worker(req.body);
 
   try {
@@ -62,11 +57,6 @@ router.delete('/workers/:_id', async (req, res) => {
     if (!worker) {
       return res.status(StatusCodes.BAD_REQUEST).send('No worker found.');
     }
-
-    if (worker.imageUrl && isStoredInCloud(worker.imageUrl)) {
-      await deleteFiles([worker.imageUrl]);
-    }
-
     return res.status(StatusCodes.OK).send();
   } catch (e) {
     return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({ error: e.message });


### PR DESCRIPTION
Removed worker's `imageUrl` field from schema. 

Added file filtering for multer image uploads: 
- Only accepts images of type `jpg` or `png`
- Max image size of 5MB
- Property endpoint accepts max of 5 photos